### PR TITLE
TEC-562 - Fix error where rather than passing in response time out va…

### DIFF
--- a/CivicConnect/Classes/Core/Session/DefaultConnectSession.swift
+++ b/CivicConnect/Classes/Core/Session/DefaultConnectSession.swift
@@ -112,7 +112,7 @@ private extension DefaultConnectSession {
         }
         
         self.response = response
-        self.timeOutTimer = AsynchronousProvider.executeInBackground(afterInterval: TimeInterval(5)) { [weak self] _ in
+        self.timeOutTimer = AsynchronousProvider.executeInBackground(afterInterval: TimeInterval(response.timeout)) { [weak self] _ in
             self?.scopeRequestTimedOut()
         }
         

--- a/Tests/DefaultConnectSessionTests.swift
+++ b/Tests/DefaultConnectSessionTests.swift
@@ -174,7 +174,7 @@ class DefaultConnectSessionTests: XCTestCase {
     }
     
     func testShouldThrowScopeRequestTimeOutErrorWhenStartingSessionAndTimeOutIsReached() {
-        let response = CivicConnect.GetScopeRequestResponse(scopeRequestString: "test", uuid: "uuid", isTest: true, status: 0, timeout: 0)
+        let response = CivicConnect.GetScopeRequestResponse(scopeRequestString: "test", uuid: "uuid", isTest: true, status: 0, timeout: 2)
         let expectedUrl = URL(string: "\(CivicConnect.Config.current.civicAppLink)?$originator=\(CivicConnect.Config.current.originatorIdentifier)&$scoperequest=test&$fallback_url=itms-apps%253A%252F%252Fitunes.apple.com%252Fapp%252Fid1141956958")
 
         let mockDelegate = MockConnectDelegate()
@@ -196,6 +196,7 @@ class DefaultConnectSessionTests: XCTestCase {
 
         XCTAssertEqual(expectedUrl, mockLauncher.lastLaunchUrl)
         XCTAssertEqual(ConnectError.scopeRequestTimeOut, mockDelegate.lastError)
+        XCTAssertEqual(2, mockAsyncRunner.executeInBackgroundTimeInterval)
     }
 
     func testShouldThrowErrorWhenGettingScopeRequestFailsWhenStartingSession() {

--- a/Tests/MockAsynchronousRunner.swift
+++ b/Tests/MockAsynchronousRunner.swift
@@ -26,7 +26,10 @@ class MockAsynchronousRunner: CivicConnect.AsynchronousRunner {
         return timer
     }
     
+    var executeInBackgroundTimeInterval: TimeInterval?
+    
     func executeInBackground(afterInterval timeInterval: TimeInterval, _ execute: @escaping (CivicConnect.AsyncTimer) -> Void) -> CivicConnect.AsyncTimer {
+        executeInBackgroundTimeInterval = timeInterval
         let timer = CivicConnect.AsyncTimer(timeInterval: timeInterval, execution: { _ in })
         fireOffTimer = { execute(timer) }
         return timer


### PR DESCRIPTION
…lue, passed in an arbitrary value

- Updated test to ensure the correct time out value is passed from the response object